### PR TITLE
fix(en/asura): use stable backend IDs for chapters

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/en/AsuraScansParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/en/AsuraScansParser.kt
@@ -183,9 +183,17 @@ internal class AsuraScansParser(context: MangaLoaderContext) :
 				val stableUrl = "/series/$slug/chapter/$chapterNum"
 				val date = div.selectLast("h3")?.text().orEmpty()
 				val cleanDate = date.replace(regexDate, "$1")
+				val titleElement = div.selectFirst("h3")
+				val chapterLabel = titleElement?.ownText()?.trim()?.takeIf { it.isNotEmpty() }
+				val chapterTitle = titleElement?.selectFirst("span")?.text()?.trim()?.takeIf { it.isNotEmpty() }
+				val fullTitle = when {
+					chapterLabel != null && chapterTitle != null -> "$chapterLabel - $chapterTitle"
+					chapterLabel != null -> chapterLabel
+					else -> chapterTitle
+				}
 				MangaChapter(
 					id = generateUid(stableUrl),
-					title = div.selectFirst("h3")?.textOrNull(),
+					title = fullTitle,
 					number = i + 1f,
 					volume = 0,
 					url = url,


### PR DESCRIPTION
## Problem
AsuraComic urls include a hash suffix (e.g., `the-indomitable-martial-king-<3deb9390>`) that changes daily. Since the parser was generating chapter ids from these urls, downloaded chapters would appear as duplicates.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/5d701c5a-2a52-4860-bc28-083e930bdd77" />

## Solution
Parse chapter data directly from asura's next.js data stream (`self.__next_f`) which contains stable backend database ids.

## Changes
- **Stable chapter ids:** Use backend database ids (e.g., `26511`) instead of url-derived hashes
- **Direct json parsing:** Extract `name` (chapter number), `title`, `id`, and `published_at` from the embedded json data
- **Iso date parsing:** Use `published_at` field for accurate upload dates instead of parsing human-readable date strings
- **Url construction:** Build chapter urls from manga slug + chapter number
- **Perf:** Moved `SimpleDateFormat` to class-level property

## Result
Downloaded chapters will now persist correctly even when asura's url hashes change daily.