### PR TITLE
Temporary fix for MangaPark's servers, generally being completely broken

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/MangaPark.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/MangaPark.kt
@@ -301,7 +301,7 @@ internal class MangaPark(context: MangaLoaderContext) :
                 if (url.indexOf("//s") != -1 && url.indexOf(".") != -1){
                     var p = url.split("//")[1]
                     p = p.substring(p.indexOf("/"))
-                    url = "https://mangapark.net$p"
+                    url = "https://$domain$p"
                 }
 				if (url.contains(".jpg") || url.contains(".jpeg") || url.contains(".jfif") || url.contains(".pjpeg") ||
 					url.contains(".pjp") || url.contains(".png") || url.contains(".webp") || url.contains(".avif") ||


### PR DESCRIPTION
MangaPark is actually quite broken, since the developers seem to not be able to fix it for now, I will submit this patch that is based on a TamperMonkey script found in their discord.

For now this patch seems to be working on my end