### PR TITLE
Update MangaDistrict.kt

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/MangaDistrict.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/en/MangaDistrict.kt
@@ -21,7 +21,7 @@ internal class MangaDistrict(context: MangaLoaderContext) :
 	override suspend fun getChapters(manga: Manga, doc: Document): List<MangaChapter> {
 		val slug = manga.url.removeSuffix('/').substringAfterLast('/')
 		val doc2 = webClient.httpPost(
-			"https://$domain/title/$slug/ajax/chapters/",
+			"https://$domain/series/$slug/ajax/chapters/",
 			mapOf(),
 		).parseHtml()
 		val ul = doc2.body().selectFirstOrThrow("ul")


### PR DESCRIPTION
Fix to the "link is missing" issue on source caused by a URL site restructure.

<img width="592" height="318" alt="Screenshot 2026-04-05 at 18 23 39" src="https://github.com/user-attachments/assets/9014a769-880b-42ab-8ef7-2d6d0d5d26b7" />
