### PR TITLE
fix(WaManga): rewrite parser for new /api/v1 endpoint

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/WaMangaParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/WaMangaParser.kt
@@ -4,7 +4,7 @@ import org.json.JSONObject
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.config.ConfigKey
-import org.koitharu.kotatsu.parsers.core.SinglePageMangaParser
+import org.koitharu.kotatsu.parsers.core.PagedMangaParser
 import org.koitharu.kotatsu.parsers.model.*
 import org.koitharu.kotatsu.parsers.util.*
 import org.koitharu.kotatsu.parsers.util.json.*
@@ -14,100 +14,102 @@ import java.util.*
 @MangaSourceParser("WAMANGA", "WaManga", "ru", type = ContentType.MANGA)
 internal class WaMangaParser(
 	context: MangaLoaderContext,
-) : SinglePageMangaParser(context, MangaParserSource.WAMANGA) {
+) : PagedMangaParser(context, MangaParserSource.WAMANGA, pageSize = 20) {
 
 	override val configKeyDomain = ConfigKey.Domain("wamanga.ru")
 
+	// The API returns the catalog in alphabetical order; no server-side sorting.
 	override val availableSortOrders: Set<SortOrder> = EnumSet.of(SortOrder.ALPHABETICAL)
 
 	override val filterCapabilities: MangaListFilterCapabilities
 		get() = MangaListFilterCapabilities(
-			isMultipleTagsSupported = true,
 			isSearchSupported = true,
 		)
 
-	override suspend fun getFilterOptions() = MangaListFilterOptions(availableTags = fetchAvailableTags())
+	override suspend fun getFilterOptions() = MangaListFilterOptions()
 
-	override suspend fun getList(order: SortOrder, filter: MangaListFilter): List<Manga> {
-		return parseMangaList(webClient.httpGet("https://$domain/api/comics").parseJson())
+	private fun apiUrl() = "https://${domain}/api/v1"
+
+	override suspend fun getListPage(page: Int, order: SortOrder, filter: MangaListFilter): List<Manga> {
+		val offset = (page - 1) * pageSize
+		val url = buildString {
+			append(apiUrl())
+			append("/manga?limit=")
+			append(pageSize)
+			append("&offset=")
+			append(offset)
+			filter.query?.takeIf { it.isNotEmpty() }?.let {
+				append("&query=")
+				append(it.urlEncoded())
+			}
+		}
+		return webClient.httpGet(url).parseJsonArray().mapJSON { parseManga(it) }
 	}
 
-	private fun parseMangaList(docs: JSONObject): List<Manga> {
-		return docs.getJSONArray("comics").mapJSONNotNull { parseSmallMangaObject(it) }
-	}
-
-	private fun parseMangaTag(doc: JSONObject): MangaTag {
-		return MangaTag(
-			doc.getString("name").toTitleCase(sourceLocale),
-			doc.getString("slug"),
-			source,
-		)
-	}
-
-	private fun parseSmallMangaObject(doc: JSONObject): Manga {
-		val url = doc.getString("url")
-		val author = doc.getStringOrNull("author")
+	private fun parseManga(jo: JSONObject): Manga {
+		val id = jo.getString("id")
+		val slug = jo.getString("slug")
 		return Manga(
-			id = generateUid(url),
-			url = url,
-			title = doc.getString("title"),
-			altTitles = emptySet(),
-			publicUrl = url.toAbsoluteUrl(domain),
-			rating = doc.getFloatOrDefault("rating", 0f),
-			coverUrl = doc.getString("thumbnail_small"),
-			tags = doc.getJSONArray("genres").mapJSONToSet { tag -> parseMangaTag(tag) },
-			state = when (doc.getString("status").lowercase(sourceLocale)) {
-				"продолжается" -> MangaState.ONGOING
-				"окончен" -> MangaState.FINISHED
-				"закончен" -> MangaState.FINISHED
-				else -> MangaState.UPCOMING
-			},
-			authors = setOfNotNull(author),
-			source = source,
-			contentRating = if (doc.getIntOrDefault("adult", 0) == 0) {
-				ContentRating.SAFE
-			} else {
+			id = generateUid(id),
+			url = id,
+			publicUrl = "https://${domain}/manga/$slug",
+			title = jo.getString("title"),
+			altTitles = collectAltTitles(jo),
+			coverUrl = jo.getStringOrNull("coverUrl")?.toAbsoluteUrl(domain),
+			largeCoverUrl = jo.getStringOrNull("imageUrl")?.toAbsoluteUrl(domain),
+			tags = parseTags(jo),
+			state = parseState(jo.getStringOrNull("statusTitle")),
+			authors = jo.optJSONArray("authors")?.asTypedList<String>()?.toSet().orEmpty(),
+			rating = RATING_UNKNOWN,
+			contentRating = if (jo.getBooleanOrDefault("isAdult", false)) {
 				ContentRating.ADULT
+			} else {
+				ContentRating.SAFE
 			},
+			source = source,
 		)
 	}
-
 
 	override suspend fun getDetails(manga: Manga): Manga {
-
-		val url = "https://$domain/api${manga.url}"
-		val doc = webClient.httpGet(url).parseJson().getJSONObject("comic")
-
+		val jo = webClient.httpGet("${apiUrl()}/manga/${manga.url}").parseJson()
+		val chaptersJson = webClient.httpGet("${apiUrl()}/manga/${manga.url}/chapters").parseJsonArray()
 		val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", sourceLocale)
+		val scanlator = jo.optJSONArray("teams")
+			?.mapJSON { it.getStringOrNull("name") }
+			?.filterNotNull()
+			?.joinToString()
+			?.takeUnless { it.isEmpty() }
 		return manga.copy(
-			url = doc.getString("url"),
-			title = doc.getString("title"),
-			largeCoverUrl = doc.getString("thumbnail"),
-			description = doc.getStringOrNull("description") ?: manga.description,
-			chapters = doc.getJSONArray("chapters").asTypedList<JSONObject>().mapChapters(reversed = true) { _, it ->
-				val chapterUrl = it.getString("url")
+			altTitles = collectAltTitles(jo),
+			description = jo.getStringOrNull("description"),
+			tags = parseTags(jo),
+			authors = jo.optJSONArray("authors")?.asTypedList<String>()?.toSet().orEmpty(),
+			state = parseState(jo.getStringOrNull("statusTitle")),
+			largeCoverUrl = jo.getStringOrNull("imageUrl")?.toAbsoluteUrl(domain) ?: manga.largeCoverUrl,
+			chapters = chaptersJson.asTypedList<JSONObject>().mapChapters { _, it ->
+				val chapterId = it.getString("id")
+				val position = it.getFloatOrDefault("position", 0f)
 				MangaChapter(
-					id = generateUid(chapterUrl),
-					url = chapterUrl,
-					source = source,
-					number = it.getFloatOrDefault("chapter", 0f),
-					volume = it.getIntOrDefault("volume", 0),
-					title = it.getStringOrNull("full_title"),
-					scanlator = it.getJSONArray("teams").getJSONObject(0)?.getStringOrNull("name"),
-					uploadDate = dateFormat.parseSafe(it.getStringOrNull("published_on")),
+					id = generateUid(chapterId),
+					url = chapterId,
+					title = it.getStringOrNull("title")?.takeUnless { t -> t.isEmpty() },
+					number = position,
+					volume = 0,
+					scanlator = scanlator,
+					uploadDate = dateFormat.parseSafe(it.getStringOrNull("createdAt")),
 					branch = null,
+					source = source,
 				)
 			},
 		)
 	}
 
 	override suspend fun getPages(chapter: MangaChapter): List<MangaPage> {
-		return webClient.httpGet("https://$domain/api${chapter.url}")
+		return webClient.httpGet("${apiUrl()}/chapters/${chapter.url}")
 			.parseJson()
-			.getJSONObject("chapter")
-			.getJSONArray("pages")
-			.asTypedList<String>()
-			.map { img ->
+			.getJSONArray("files")
+			.mapJSON { file ->
+				val img = file.getString("diskFile").toAbsoluteUrl(domain)
 				MangaPage(
 					id = generateUid(img),
 					url = img,
@@ -117,14 +119,30 @@ internal class WaMangaParser(
 			}
 	}
 
-	private suspend fun fetchAvailableTags(): Set<MangaTag> {
-		val doc = webClient.httpGet("https://$domain/api/comics").parseJson()
-		return doc
-			.getJSONArray("comics")
-			.mapJSONNotNull { it.getJSONArray("genres").mapJSONToSet { tag -> parseMangaTag(tag) } }
-			.flatten()
-			.distinctBy { it.key }
-			.filter { it.key != "" }
-			.toSet()
+	private fun collectAltTitles(jo: JSONObject): Set<String> = buildSet {
+		jo.getStringOrNull("titleEnglish")?.takeUnless { it.isEmpty() }?.let(::add)
+		jo.optJSONArray("alternateTitles")?.asTypedList<String>()?.forEach { if (it.isNotEmpty()) add(it) }
+	}
+
+	private fun parseTags(jo: JSONObject): Set<MangaTag> {
+		return jo.optJSONArray("genres")?.asTypedList<String>()?.mapNotNullToSet { name ->
+			if (name.isEmpty()) {
+				null
+			} else {
+				MangaTag(
+					title = name.toTitleCase(sourceLocale),
+					key = name,
+					source = source,
+				)
+			}
+		}.orEmpty()
+	}
+
+	private fun parseState(status: String?) = when (status?.lowercase(sourceLocale)) {
+		"ongoing" -> MangaState.ONGOING
+		"finished", "completed" -> MangaState.FINISHED
+		"abandoned" -> MangaState.ABANDONED
+		"paused", "frozen" -> MangaState.PAUSED
+		else -> null
 	}
 }


### PR DESCRIPTION
## Problem

`wamanga.ru` migrated to an SPA backed by a new API. The endpoint `/api/comics` used by the current parser now returns **404**, so the WaManga source is broken (empty catalog / load errors).

## Fix

Rewrote `WaMangaParser` against the new `/api/v1` API and switched from `SinglePageMangaParser` to `PagedMangaParser`:

- **catalog:** `GET /api/v1/manga?limit=&offset=`
- **search:** `&query=`
- **details:** `GET /api/v1/manga/{id}` (+ `/manga/{id}/chapters`)
- **pages:** `GET /api/v1/chapters/{id}` → `files[].diskFile`

Notes:
- The new API has no working server-side genre filtering (genre params are ignored or return 500), so tag filtering is intentionally not advertised. Search and pagination work.

## Testing

Verified against the live site with the repo's test harness (`MangaParserTest`, `names = ["WAMANGA"]`):

- ✅ `list`
- ✅ `pagination`
- ✅ `search`
- ✅ `details`
- ✅ `pages`
