### PR TITLE
Update HentaiOrigines source URL from .fr to .com

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/HentaiOrigines.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/fr/HentaiOrigines.kt
@@ -8,4 +8,4 @@ import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 
 @MangaSourceParser("HENTAIORIGINES", "HentaiOrigines", "fr", ContentType.HENTAI)
 internal class HentaiOrigines(context: MangaLoaderContext) :
-	MadaraParser(context, MangaParserSource.HENTAIORIGINES, "hentai-origines.fr")
+	MadaraParser(context, MangaParserSource.HENTAIORIGINES, "hentai-origines.com")


### PR DESCRIPTION
I change the URL of Hentaiorgines with the new URL