### PR TITLE
fix(desu): replace deprecated API

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/DesuMeParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/ru/DesuMeParser.kt
@@ -3,6 +3,10 @@ package org.koitharu.kotatsu.parsers.site.ru
 import androidx.collection.ArrayMap
 import okhttp3.Headers
 import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.json.JSONArray
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.config.ConfigKey
@@ -11,16 +15,16 @@ import org.koitharu.kotatsu.parsers.exception.ParseException
 import org.koitharu.kotatsu.parsers.model.*
 import org.koitharu.kotatsu.parsers.network.UserAgents
 import org.koitharu.kotatsu.parsers.util.*
-import org.koitharu.kotatsu.parsers.util.json.*
 import org.koitharu.kotatsu.parsers.util.suspendlazy.getOrNull
 import org.koitharu.kotatsu.parsers.util.suspendlazy.suspendLazy
 import java.util.*
 
 @MangaSourceParser("DESUME", "Desu", "ru")
 internal class DesuMeParser(context: MangaLoaderContext) :
-    PagedMangaParser(context, MangaParserSource.DESUME, 20) {
+    PagedMangaParser(context, MangaParserSource.DESUME, pageSize = 24, searchPageSize = 20) {
 
     override val configKeyDomain = ConfigKey.Domain(
+        "desu.uno",
         "x.desu.city",
         "" +
             "desu.city",
@@ -40,7 +44,6 @@ internal class DesuMeParser(context: MangaLoaderContext) :
         get() = MangaListFilterCapabilities(
             isMultipleTagsSupported = true,
             isSearchSupported = true,
-            isSearchWithFiltersSupported = true,
         )
 
     override suspend fun getFilterOptions() = MangaListFilterOptions(
@@ -54,126 +57,161 @@ internal class DesuMeParser(context: MangaLoaderContext) :
     private val tagsCache = suspendLazy(initializer = ::fetchTags)
 
     override suspend fun getListPage(page: Int, order: SortOrder, filter: MangaListFilter): List<Manga> {
-        if (!filter.query.isNullOrEmpty() && page != searchPaginator.firstPage) {
-            return emptyList()
+        val query = filter.query?.trim().orEmpty()
+        if (query.isNotEmpty()) {
+            if (page != searchPaginator.firstPage) {
+                return emptyList()
+            }
+            val url = "https://$domain/manga/search/".toHttpUrl().newBuilder()
+                .addQueryParameter("q", query)
+                .build()
+            return parseSearch(webClient.httpGet(url).parseHtml())
         }
-        val domain = domain
-        val url = buildString {
-            append("https://")
-            append(domain)
-            append("/manga/api/?limit=20&order=")
-            append(getSortKey(order))
-            append("&page=")
-            append(page)
+        val url = "https://$domain/manga/".toHttpUrl().newBuilder().apply {
+            if (page != paginator.firstPage) {
+                addQueryParameter("page", page.toString())
+            }
+            if (order != SortOrder.UPDATED) {
+                addQueryParameter("order_by", getSortKey(order))
+            }
             if (filter.tags.isNotEmpty()) {
-                append("&genres=")
-                filter.tags.joinTo(this, ",") { it.key }
+                addQueryParameter("genres", filter.tags.joinToString(",") { it.key })
             }
-            if (!filter.query.isNullOrEmpty()) {
-                append("&search=")
-                append(filter.query)
-            }
-        }
-        val json = webClient.httpGet(url).parseJson().getJSONArray("response")
-            ?: throw ParseException("Invalid response", url)
-        val total = json.length()
-        val list = ArrayList<Manga>(total)
-        val tagsMap = tagsCache.getOrNull()
-        for (i in 0 until total) {
-            val jo = json.getJSONObject(i)
-            val cover = jo.getJSONObject("image")
-            val id = jo.getLong("id")
-            val genres = jo.getString("genres").split(',')
-            list += Manga(
-                url = "/manga/api/$id",
-                publicUrl = jo.getString("url"),
-                source = MangaParserSource.DESUME,
-                title = jo.getString("russian"),
-                altTitles = setOf(jo.getString("name")),
-                coverUrl = cover.getString("preview"),
-                largeCoverUrl = cover.getString("original"),
-                state = when (jo.getString("status")) {
-                    "ongoing" -> MangaState.ONGOING
-                    "released" -> MangaState.FINISHED
-                    else -> null
-                },
-                rating = jo.getDouble("score").toFloat().coerceIn(0f, 1f),
-                id = generateUid(id),
-                contentRating = null,
-                tags = if (!tagsMap.isNullOrEmpty()) {
-                    genres.mapNotNullToSet { g ->
-                        tagsMap[g.trim().toTitleCase()]
-                    }
-                } else {
-                    emptySet()
-                },
-                authors = emptySet(),
-                description = jo.getString("description"),
-            )
-        }
-        return list
+        }.build()
+        return parseCatalog(webClient.httpGet(url).parseHtml())
     }
 
     override suspend fun getDetails(manga: Manga): Manga {
-        val url = manga.url.toAbsoluteUrl(domain)
-        val json = webClient.httpGet(url).parseJson().getJSONObject("response")
-            ?: throw ParseException("Invalid response", url)
-        val baseChapterUrl = manga.url + "/chapter/"
-        val chaptersList = json.getJSONObject("chapters").getJSONArray("list")
+        val storedUrl = manga.url.findGroupValue(LEGACY_MANGA_URL_REGEX)?.let { "/manga/$it/" } ?: manga.url
+        val doc = webClient.httpGet(storedUrl.toAbsoluteUrl(domain)).parseHtml()
+        val publicUrl = doc.selectFirst("#animeView > link[itemprop=url]")
+            ?.attrAsAbsoluteUrlOrNull("href") ?: storedUrl.toAbsoluteUrl(domain)
         return manga.copy(
-            tags = json.getJSONArray("genres").mapJSONToSet {
-                MangaTag(
-                    key = it.getString("text"),
-                    title = it.getString("russian").toTitleCase(),
-                    source = manga.source,
-                )
+            url = publicUrl.toRelativeUrl(domain),
+            publicUrl = publicUrl,
+            largeCoverUrl = doc.selectFirst("meta[property=og:image]")
+                ?.attrAsAbsoluteUrlOrNull("content") ?: manga.largeCoverUrl,
+            tags = doc.select(".b-entry-info a[itemprop=genre]").mapNotNullToSet { element ->
+                val key = element.attr("href").substringAfter("genres=", "").takeIf(String::isNotEmpty)
+                    ?: return@mapNotNullToSet null
+                MangaTag(key, element.text().removePrefix("#").trim(), manga.source)
             },
-            publicUrl = json.getString("url"),
-            description = json.getString("description"),
-            chapters = chaptersList.mapJSON { jo ->
-                val chid = jo.getLong("id")
-                val volume = jo.getIntOrDefault("vol", 0)
-                val number = jo.getFloatOrDefault("ch", 0f)
+            description = doc.selectFirst("#description .russian")?.textOrNull(),
+            chapters = doc.select(".chlist > li").mapChapters(reversed = true) { _, item ->
+                val link = item.selectFirst("h4 > a[href]") ?: return@mapChapters null
+                val url = link.attrAsAbsoluteUrl("href").toRelativeUrl(domain)
                 MangaChapter(
-                    id = generateUid(chid),
+                    id = item.selectFirst("[data-chapters_id]")?.attr("data-chapters_id")
+                        ?.toLongOrNull()?.let(::generateUid) ?: generateUid(url),
                     source = manga.source,
-                    url = "$baseChapterUrl$chid",
-                    uploadDate = jo.getLong("date") * 1000,
-                    title = jo.getStringOrNull("title"),
-                    volume = volume,
-                    number = number,
+                    url = url,
+                    uploadDate = 0L,
+                    title = link.attrOrNull("title"),
+                    volume = url.findGroupValue(VOLUME_REGEX)?.toIntOrNull() ?: 0,
+                    number = url.findGroupValue(CHAPTER_REGEX)?.replace(',', '.')?.toFloatOrNull() ?: 0f,
                     scanlator = null,
                     branch = null,
                 )
-            }.reversed(),
+            },
         )
     }
 
     override suspend fun getPages(chapter: MangaChapter): List<MangaPage> {
         val fullUrl = chapter.url.toAbsoluteUrl(domain)
-        val json = webClient.httpGet(fullUrl)
-            .parseJson()
-            .getJSONObject("response") ?: throw ParseException("Invalid response", fullUrl)
-        val chapterId = chapter.url.substringAfterLast("/")
-        return json.getJSONObject("pages").getJSONArray("list").mapJSON { jo ->
-            val pageNum = jo.getLong("page")
+        val script = webClient.httpGet(fullUrl).parseHtml().select("script").firstNotNullOfOrNull { element ->
+            element.data().takeIf { "Reader.init" in it }
+        } ?: throw ParseException("Reader configuration not found", fullUrl)
+        val directory = script.findGroupValue(READER_DIRECTORY_REGEX)?.toAbsoluteUrl(domain)
+            ?: throw ParseException("Reader image directory not found", fullUrl)
+        val images = JSONArray(
+            script.findGroupValue(READER_IMAGES_REGEX)
+                ?: throw ParseException("Reader images not found", fullUrl),
+        )
+        return List(images.length()) { index ->
+            val url = concatUrl(directory, images.getJSONArray(index).getString(0))
             MangaPage(
-                id = generateUid("$chapterId-$pageNum"),
+                id = generateUid(url),
                 preview = null,
                 source = chapter.source,
-                url = jo.getString("img"),
+                url = url,
             )
         }
     }
 
     override suspend fun resolveLink(resolver: LinkResolver, link: HttpUrl): Manga? {
         val doc = webClient.httpGet(link).parseHtml()
-        val mangaId = doc.getElementsByAttribute("data-manga_id").firstNotNullOfOrNull { element ->
-            element.attrOrNull("data-manga_id")
-        } ?: return null
-        val title = doc.metaValue("headline") ?: return null
-        return resolver.resolveManga(this, id = generateUid(mangaId), url = "/manga/api/$mangaId", title = title)
+        val publicUrl = doc.selectFirst("#animeView > link[itemprop=url]")
+            ?.attrAsAbsoluteUrlOrNull("href") ?: return null
+        val mangaId = publicUrl.findGroupValue(MANGA_ID_REGEX)?.toLongOrNull() ?: return null
+        val title = doc.selectFirst(".titleBar .rus-name")?.textOrNull() ?: return null
+        return resolver.resolveManga(
+            this,
+            id = generateUid(mangaId),
+            url = publicUrl.toRelativeUrl(domain),
+            title = title,
+        )
     }
+
+    private suspend fun parseCatalog(doc: Document): List<Manga> {
+        val tagsMap = tagsCache.getOrNull()
+        return doc.select(".animeList .memberListItem").mapNotNull { item ->
+            val link = item.selectFirst("a.animeTitle[href]") ?: return@mapNotNull null
+            val publicUrl = link.attrAsAbsoluteUrl("href")
+            val url = publicUrl.toRelativeUrl(domain)
+            val mangaId = url.findGroupValue(MANGA_ID_REGEX)?.toLongOrNull() ?: return@mapNotNull null
+            val originalTitle = link.text()
+            val title = item.selectFirst(".dimmed.oTitle [itemprop=title]")?.text().orEmpty()
+                .ifBlank { originalTitle }
+            Manga(
+                url = url,
+                publicUrl = publicUrl,
+                source = source,
+                title = title,
+                altTitles = setOfNotNull(originalTitle.takeIf { it != title }),
+                coverUrl = item.selectFirst("a.avatar .img")?.styleValueOrNull("background-image")
+                    ?.cssUrl()?.trim('\'', '"')?.toAbsoluteUrl(domain),
+                state = null,
+                rating = item.info("Рейтинг")?.toFloatOrNull()?.div(10f) ?: RATING_UNKNOWN,
+                id = generateUid(mangaId),
+                contentRating = null,
+                tags = item.info("Жанры")?.split(',')?.mapNotNullToSet { genre ->
+                    tagsMap?.get(genre.trim().toTitleCase())
+                } ?: emptySet(),
+                authors = emptySet(),
+            )
+        }
+    }
+
+    private fun parseSearch(doc: Document): List<Manga> {
+        val row = doc.select("#acpQuickSearch tr").firstOrNull {
+            it.selectFirst("th")?.text() == "Манга"
+        } ?: return emptyList()
+        return row.select("td li > a[href]").mapNotNull { link ->
+            val publicUrl = link.attrAsAbsoluteUrl("href")
+            val url = publicUrl.toRelativeUrl(domain)
+            val mangaId = url.findGroupValue(MANGA_ID_REGEX)?.toLongOrNull() ?: return@mapNotNull null
+            val originalTitle = link.selectFirst(".itemTitle")?.text().orEmpty()
+            val title = link.selectFirst(".itemSubTitle")?.text().orEmpty().ifBlank { originalTitle }
+            Manga(
+                url = url,
+                publicUrl = publicUrl,
+                source = source,
+                title = title,
+                altTitles = setOfNotNull(originalTitle.takeIf { it != title }),
+                coverUrl = link.selectFirst("img")?.src(),
+                state = null,
+                rating = RATING_UNKNOWN,
+                id = generateUid(mangaId),
+                contentRating = null,
+                tags = emptySet(),
+                authors = emptySet(),
+            )
+        }
+    }
+
+    private fun Element.info(key: String): String? = select(".animeInfo dl").firstOrNull {
+        it.selectFirst("dt")?.text() == "$key:"
+    }?.selectFirst("dd")?.textOrNull()
 
     private fun getSortKey(sortOrder: SortOrder) =
         when (sortOrder) {
@@ -192,11 +230,15 @@ internal class DesuMeParser(context: MangaLoaderContext) :
         val result = ArrayMap<String, MangaTag>(li.size)
         for (it in li) {
             val input = it.selectFirst("input") ?: continue
+            val genreId = input.attr("data-genre-id").ifEmpty {
+                it.parseFailed("data-genre-id is empty")
+            }
+            val genreSlug = input.attr("data-genre-slug").ifEmpty {
+                it.parseFailed("data-genre-slug is empty")
+            }
             val tag = MangaTag(
                 source = source,
-                key = input.attr("data-genre-slug").ifEmpty {
-                    it.parseFailed("data-genre-slug is empty")
-                },
+                key = "$genreId-$genreSlug",
                 title = input.attr("data-genre-name").toTitleCase().ifEmpty {
                     it.parseFailed("data-genre-name is empty")
                 },
@@ -204,5 +246,17 @@ internal class DesuMeParser(context: MangaLoaderContext) :
             result[tag.title] = tag
         }
         return result
+    }
+
+    private companion object {
+        val MANGA_ID_REGEX = Regex("""\.(\d+)/?$""")
+        val LEGACY_MANGA_URL_REGEX = Regex("""/manga/api/(\d+)/?$""")
+        val VOLUME_REGEX = Regex("""/vol(\d+)/""")
+        val CHAPTER_REGEX = Regex("""/ch([\d.,]+)/""")
+        val READER_DIRECTORY_REGEX = Regex("""dir:\s*["']([^"']+)["']""")
+        val READER_IMAGES_REGEX = Regex(
+            """images:\s*(\[\[.*?]])\s*,\s*page:""",
+            RegexOption.DOT_MATCHES_ALL,
+        )
     }
 }

--- a/src/test/kotlin/org/koitharu/kotatsu/parsers/site/ru/DesuMeParserTest.kt
+++ b/src/test/kotlin/org/koitharu/kotatsu/parsers/site/ru/DesuMeParserTest.kt
@@ -1,0 +1,30 @@
+package org.koitharu.kotatsu.parsers.site.ru
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.koitharu.kotatsu.parsers.MangaLoaderContextMock
+import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.util.generateUid
+import org.koitharu.kotatsu.test_util.mangaOf
+
+internal class DesuMeParserTest {
+
+    @Test
+    fun migrateLegacyApiMangaUrl() = runTest {
+        val parser = MangaLoaderContextMock.newParserInstance(MangaParserSource.DESUME)
+        val legacyManga = mangaOf(MangaParserSource.DESUME, "https://desu.uno/manga/api/2602").copy(
+            id = parser.generateUid(2602L),
+        )
+
+        val details = parser.getDetails(legacyManga)
+
+        assertEquals(legacyManga.id, details.id)
+        assertFalse("/manga/api/" in details.url)
+        assertTrue(details.url.endsWith(".2602/"))
+        assertTrue(details.publicUrl.endsWith(".2602/"))
+        assertFalse(details.chapters.isNullOrEmpty())
+    }
+}


### PR DESCRIPTION
What changed

- Replaced deprecated `/manga/api/` requests with current HTML catalog, details, and reader parsing.
- Added `desu.uno` as default domain.
- Updated pagination, search, sorting, and genre filters for current website routes.
- Preserved Kotatsu 9.8.0 library entries by migrating legacy `/manga/api/{id}` URLs.
- Added focused legacy URL regression test.

Testing

Passed:

- catalog
- pagination
- title search
- single and multiple genre filters
- details
- pages
- domain
- link resolution
- legacy `/manga/api/{id}` migration

_Used gpt5.6sol_xhigh. Sorry for ai slop, I just want to read from my favorite source again._
