### PR TITLE
docs: initialize fork documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# Agent Instructions
+
+## Toolchain
+- Use the checked-in Gradle wrapper: `./gradlew`.
+- Use JDK 17; the Kotlin modules target JVM toolchain 17.
+
+## Commands
+| Task | Command |
+|------|---------|
+| Run one test class | `./gradlew test --tests "fully.qualified.TestClass"` |
+| Run parser integration tests | `./gradlew test --tests "org.koitharu.kotatsu.parsers.MangaParserTest"` |
+| Run all tests | `./gradlew test` |
+| Compile the main library | `./gradlew compileKotlin` |
+| Compile the KSP processor | `./gradlew :kotatsu-parsers-ksp:compileKotlin` |
+| Run all checks | `./gradlew check` |
+| Generate the HTML test report | `./gradlew generateTestsReport` |
+
+## External References
+| Need | File |
+|------|------|
+| Project usage and scope | `README.md` |
+| Parser design and testing | `CONTRIBUTING.md` |
+| Local development | `docs/development.md` |
+| Fork maintenance policy | `docs/maintenance.md` |
+| Current roadmap | `docs/plan.md` |
+| Parser class hierarchy | `docs/parser_classes.png` |
+
+## Git Workflow
+- Before implementation, run `git fetch --prune`, inspect local and upstream state, and start from the latest target branch without discarding uncommitted work.
+- Delete a completed local branch only when it is merged into its target and its upstream branch is gone.
+
+## Key Conventions
+- Put source-specific parsers under `src/main/kotlin/org/koitharu/kotatsu/parsers/site/`.
+- Reuse an existing site-engine base parser when the source uses that engine.
+- Use null-safe helpers from `src/main/kotlin/org/koitharu/kotatsu/parsers/util/` instead of raw JSoup helpers.
+- Annotate concrete parsers with `@MangaSourceParser` and give them one primary constructor parameter of type `MangaLoaderContext`.
+- Configure the default host through `configKeyDomain`; use `domain` at runtime instead of hardcoding hosts.
+- Generate domain-independent IDs from relative URLs or source IDs with the existing `generateUid` helpers.
+- Choose `PagedMangaParser` for page-based pagination and `SinglePageMangaParser` for non-paginated sources.
+- Keep `availableSortOrders` non-empty.
+- To select parser integration cases, temporarily edit `src/test/kotlin/org/koitharu/kotatsu/parsers/MangaSources.kt`; do not commit that selection change.
+- Do not edit `build/generated/` outputs or `.github/summary.yaml` by hand; KSP produces them.

--- a/README.md
+++ b/README.md
@@ -1,72 +1,73 @@
-# Kotatsu parsers
+# Kotatsu Parsers Redo
 
-This library provides a collection of manga parsers for convenient access manga available on the web. It can be used in
-JVM and Android applications.
+A maintained fork of [KotatsuApp/kotatsu-parsers](https://github.com/KotatsuApp/kotatsu-parsers) for [Kotatsu-Redo](https://github.com/Kotatsu-Redo/Kotatsu-Redo) and other Kotlin/JVM or Android clients.
 
-![Sources count](https://img.shields.io/badge/dynamic/yaml?url=https%3A%2F%2Fraw.githubusercontent.com%2FKotatsuApp%2Fkotatsu-parsers%2Frefs%2Fheads%2Fmaster%2F.github%2Fsummary.yaml&query=total&label=manga%20sources&color=%23E9321C) [![](https://jitpack.io/v/KotatsuApp/kotatsu-parsers.svg)](https://jitpack.io/#KotatsuApp/kotatsu-parsers) ![License](https://img.shields.io/github/license/KotatsuApp/Kotatsu) [![Telegram](https://img.shields.io/badge/chat-telegram-60ACFF)](https://t.me/kotatsuapp) [![Discord](https://img.shields.io/discord/898363402467045416?color=5865f2&label=discord)](https://discord.gg/NNJ5RgVBC5)
+[![Sources](https://img.shields.io/badge/dynamic/yaml?url=https%3A%2F%2Fraw.githubusercontent.com%2FKotatsu-Redo%2Fkotatsu-parsers-redo%2Frefs%2Fheads%2Fmaster%2F.github%2Fsummary.yaml&query=total&label=manga%20sources&color=%23E9321C)](.github/summary.yaml)
+[![JitPack](https://jitpack.io/v/Kotatsu-Redo/kotatsu-parsers-redo.svg)](https://jitpack.io/#Kotatsu-Redo/kotatsu-parsers-redo)
+[![License: GPL-3.0](https://img.shields.io/github/license/Kotatsu-Redo/kotatsu-parsers-redo)](LICENSE)
 
-## Usage
+The fork preserves the original parser API while maintaining source integrations and compatibility needed by Kotatsu-Redo. The project contains the parser library and a KSP module that generates the source registry and summary metadata.
 
-1. Add it to your root build.gradle at the end of repositories:
+## Use the library
 
-   ```groovy
-   allprojects {
-	   repositories {
-		   ...
-		   maven { url 'https://jitpack.io' }
-	   }
-   }
-   ```
+Add JitPack to your repositories:
 
-2. Add the dependency
+```kotlin
+repositories {
+    maven("https://jitpack.io")
+}
+```
 
-   For Java/Kotlin project:
-    ```groovy
-    dependencies {
-        implementation("com.github.KotatsuApp:kotatsu-parsers:$parsers_version")
+Add a tagged version, commit hash, or JitPack snapshot as the dependency version:
+
+```kotlin
+dependencies {
+    implementation("com.github.Kotatsu-Redo:kotatsu-parsers-redo:<version>")
+}
+```
+
+For Android, exclude the JVM `org.json` implementation:
+
+```kotlin
+dependencies {
+    implementation("com.github.Kotatsu-Redo:kotatsu-parsers-redo:<version>") {
+        exclude(group = "org.json", module = "json")
     }
-    ```
+}
+```
 
-   For Android project:
-    ```groovy
-    dependencies {
-        implementation("com.github.KotatsuApp:kotatsu-parsers:$parsers_version") {
-            exclude group: 'org.json', module: 'json'
-        }
-    }
-    ```
+Android consumers must enable [core library desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring), including the required NIO APIs.
 
-   Versions are available on [JitPack](https://jitpack.io/#KotatsuApp/kotatsu-parsers)
+Create a parser through your `MangaLoaderContext` implementation:
 
-   When used in Android
-   projects, [core library desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) with
-   the [NIO specification](https://developer.android.com/studio/write/java11-nio-support-table) should be enabled to
-   support Java 8+ features.
+```kotlin
+val parser = mangaLoaderContext.newParserInstance(MangaParserSource.MANGADEX)
+```
 
+Reference implementations are available for [Android](https://github.com/KotatsuApp/Kotatsu/blob/devel/app/src/main/kotlin/org/koitharu/kotatsu/core/parser/MangaLoaderContextImpl.kt) and [JVM](https://github.com/KotatsuApp/kotatsu-dl/blob/master/src/main/kotlin/org/koitharu/kotatsu/dl/parsers/MangaLoaderContextImpl.kt) clients.
 
-3. Usage in code
+## Develop
 
-   ```kotlin
-   val parser = mangaLoaderContext.newParserInstance(MangaParserSource.MANGADEX)
-   ```
+Requirements:
 
-   `mangaLoaderContext` is an implementation of the `MangaLoaderContext` class.
-   See examples
-   of [Android](https://github.com/KotatsuApp/Kotatsu/blob/devel/app/src/main/kotlin/org/koitharu/kotatsu/core/parser/MangaLoaderContextImpl.kt)
-   and [Non-Android](https://github.com/KotatsuApp/kotatsu-dl/blob/master/src/main/kotlin/org/koitharu/kotatsu/dl/parsers/MangaLoaderContextImpl.kt)
-   implementation.
+- JDK 17
+- the checked-in Gradle wrapper
 
-## Projects that use the library
+```shell
+git clone https://github.com/Kotatsu-Redo/kotatsu-parsers-redo.git
+cd kotatsu-parsers-redo
+./gradlew check
+```
 
-- [Kotatsu-Redo](https://github.com/Kotatsu-Redo/Kotatsu-Redo)
-- [Futon](https://github.com/AppFuton/Futon)
-- [Kototoro](https://github.com/Kototoro-app/Kototoro)
-  
-## Contribution
+See:
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for the guidelines.
+- [Development guide](docs/development.md) for project layout and commands
+- [Parser contribution guide](CONTRIBUTING.md) for parser implementation details
+- [Fork maintenance policy](docs/maintenance.md) for scope and upstream handling
+- [Plan](docs/plan.md) for current initialization and maintenance work
 
-## DMCA disclaimer
+## License and content disclaimer
 
-The developers of this application have no affiliation with the content available in the app. It is collected from
-sources freely available through any web browser.
+This fork retains the upstream [GPL-3.0 license](LICENSE).
+
+The maintainers are not affiliated with the websites accessed by the parsers and do not host their content. Parsers access information already available through a web browser. Source owners can use the repository's issue templates to report a concern or request removal.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,48 @@
+# Development
+
+## Prerequisites
+
+- JDK 17
+- Git
+- A network connection for Gradle dependencies and live parser integration tests
+
+Use `./gradlew` rather than a system Gradle installation.
+
+## Repository layout
+
+| Path | Purpose |
+|------|---------|
+| `src/main/kotlin/org/koitharu/kotatsu/parsers/` | Public API, parser runtime, models, and utilities |
+| `src/main/kotlin/org/koitharu/kotatsu/parsers/site/` | Concrete source parsers and shared site-engine parsers |
+| `src/test/kotlin/` | Unit and live parser integration tests |
+| `kotatsu-parsers-ksp/` | KSP processor that generates the parser source registry |
+| `.github/summary.yaml` | KSP-generated source summary |
+
+The parser class hierarchy is illustrated in [parser_classes.png](parser_classes.png). Detailed parser conventions are in [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+## Common commands
+
+| Task | Command |
+|------|---------|
+| Compile the library | `./gradlew compileKotlin` |
+| Compile the KSP processor | `./gradlew :kotatsu-parsers-ksp:compileKotlin` |
+| Run all tests | `./gradlew test` |
+| Run all checks | `./gradlew check` |
+| Run one test class | `./gradlew test --tests "fully.qualified.TestClass"` |
+| Run parser integration tests | `./gradlew test --tests "org.koitharu.kotatsu.parsers.MangaParserTest"` |
+| Generate an HTML parser report | `./gradlew generateTestsReport` |
+
+Live parser tests depend on third-party websites and may fail because of rate limits, blocking, downtime, or site changes. Record enough response context to distinguish infrastructure failures from parser regressions.
+
+## Test selected parsers
+
+Temporarily edit `src/test/kotlin/org/koitharu/kotatsu/parsers/MangaSources.kt`:
+
+1. Add parser enum names to `names`.
+2. Keep `mode = EnumSource.Mode.INCLUDE`.
+3. Run `MangaParserTest`.
+4. Restore the file before committing.
+
+## Generated files
+
+KSP generates source code under `build/generated/` and updates `.github/summary.yaml`. Do not edit either output manually. Change the parser annotations or KSP processor, then rerun the relevant Gradle task.

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,0 +1,47 @@
+# Fork maintenance
+
+## Purpose
+
+Kotatsu Parsers Redo continues the parser library for Kotatsu-Redo while retaining compatibility with the original `org.koitharu.kotatsu.parsers` API where practical. The fork prioritizes:
+
+1. keeping active sources functional;
+2. supporting Kotatsu-Redo integration;
+3. accepting focused source fixes and additions;
+4. preserving a usable Kotlin/JVM and Android library API.
+
+The original [KotatsuApp/kotatsu-parsers](https://github.com/KotatsuApp/kotatsu-parsers) repository remains the historical upstream and attribution source.
+
+## Change policy
+
+- Prefer small parser-specific changes over unrelated refactors.
+- Reuse shared engine parsers when several sources have the same implementation.
+- Treat source URLs, page structures, and undocumented APIs as unstable external contracts.
+- Keep parser IDs domain-independent so domain changes do not invalidate client data.
+- Document intentional API incompatibilities in the pull request and release notes.
+- Do not remove a source without confirming that it is permanently unavailable, superseded, or subject to a valid removal request.
+
+## Upstream changes
+
+Before importing changes from another repository:
+
+1. identify the exact commits and affected parsers;
+2. review them against this fork's current code instead of merging blindly;
+3. preserve original authorship and license notices;
+4. run focused tests, followed by `./gradlew check` when practical;
+5. record conflicts or deliberate deviations in the pull request.
+
+## Releases
+
+Until an automated release policy is established, JitPack can build a commit hash or branch snapshot. Consumers that require reproducible builds should pin a tag or full commit hash rather than a moving snapshot. Release automation and versioning remain tracked in [plan.md](plan.md).
+
+## Triage
+
+When a parser breaks, capture:
+
+- source and configured domain;
+- failing operation (list, search, details, chapters, or pages);
+- relevant HTTP status or sanitized response details;
+- whether the site works in a normal browser;
+- whether anti-bot protection or authentication is involved.
+
+Never publish credentials, session cookies, access tokens, or personal reading data.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,0 +1,31 @@
+# Fork initialization plan
+
+This document tracks repository-level work for making Kotatsu Parsers Redo independently maintainable. Parser-specific bugs belong in GitHub issues rather than this plan.
+
+## Completed
+
+- [x] Identify the project as the Kotatsu-Redo maintained fork.
+- [x] Point README badges and dependency coordinates at this repository.
+- [x] Document JDK 17, Gradle commands, generated outputs, and focused parser testing.
+- [x] Document fork scope and upstream-change handling.
+- [x] Add repository instructions for coding agents.
+
+## Next
+
+- [ ] Add CI that runs compilation, unit tests, and KSP validation on JDK 17.
+- [ ] Separate deterministic unit tests from live website integration tests in CI.
+- [ ] Define semantic versioning, tagging, release notes, and a reproducible publishing workflow.
+- [ ] Publish and verify the first fork-owned dependency artifact.
+- [ ] Audit issue templates, repository links, and community references inherited from upstream.
+- [ ] Establish a baseline of active, broken, protected, and retired sources.
+
+## Later
+
+- [ ] Add regression fixtures for shared parser engines where responses can be tested offline.
+- [ ] Document API compatibility expectations for Kotatsu-Redo and third-party clients.
+- [ ] Automate source-health reporting without treating transient site failures as code regressions.
+- [ ] Review generated source metadata in CI and fail when committed output is stale.
+
+## Definition of initialized
+
+The fork is initialized when validation runs on every pull request, a versioned artifact can be reproduced from a tag, fork-owned links and policies are in place, and maintainers have a documented process for triaging parser failures.


### PR DESCRIPTION
## Summary

- identify the repository as the Kotatsu-Redo maintained fork
- document library usage, development commands, and maintenance policy
- add the fork initialization roadmap and coding-agent guidance

## Validation

- `git diff --check`
- verified local Markdown links