### PR TITLE
Added Webtoons direct-link resolution

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/LineWebtoonsParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/LineWebtoonsParser.kt
@@ -243,8 +243,8 @@ internal abstract class LineWebtoonsParser(
 	}
 
 	override suspend fun resolveLink(resolver: LinkResolver, link: HttpUrl): Manga? {
-		val titleNo = link.queryParameter("title_no") ?: return null
-		return resolver.resolveManga(this, url = titleNo)
+		// These legacy sources share the domain and may win global routing.
+		return context.newParserInstance(MangaParserSource.WEBTOONS_EN).resolveLink(resolver, link)
 	}
 
 	private fun parseTag(jo: JSONObject): MangaTag {

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/WebtoonsParser.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/all/WebtoonsParser.kt
@@ -3,6 +3,7 @@ package org.koitharu.kotatsu.parsers.site.all
 import androidx.collection.arraySetOf
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import okhttp3.HttpUrl
 import org.jsoup.nodes.Element
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
@@ -23,6 +24,58 @@ internal abstract class WebtoonsParser(
 
 	private val mobileApiDomain = "m.webtoons.com"
 	private val staticDomain = "webtoon-phinf.pstatic.net"
+
+	override suspend fun resolveLink(resolver: LinkResolver, link: HttpUrl): Manga? {
+		if (link.host !in setOf("webtoons.com", "www.webtoons.com", mobileApiDomain)) return null
+		val segments = link.pathSegments
+		val targetSource = when (segments.firstOrNull()) {
+			"en" -> MangaParserSource.WEBTOONS_EN
+			"id" -> MangaParserSource.WEBTOONS_ID
+			"es" -> MangaParserSource.WEBTOONS_ES
+			"fr" -> MangaParserSource.WEBTOONS_FR
+			"th" -> MangaParserSource.WEBTOONS_TH
+			"zh-hant" -> MangaParserSource.WEBTOONS_ZH
+			"de" -> MangaParserSource.WEBTOONS_DE
+			else -> return null
+		}
+		when (segments.lastOrNull()) {
+			"list" -> if (segments.size != 4) return null
+			"viewer" -> if (segments.size !in 4..5) return null
+			else -> return null
+		}
+		if (segments.any { it.isBlank() }) return null
+		val titleParam = link.queryParameterValues("title_no").singleOrNull() ?: return null
+		if (titleParam.isEmpty() || titleParam.any { it !in '0'..'9' }) return null
+		val titleNo = titleParam.toLongOrNull()?.takeIf { it > 0 } ?: return null
+
+		// All locales share a domain, so the generic resolver may select any sibling.
+		// The factory returns a wrapper: use its interface instead of casting it.
+		val parser = if (targetSource == source) this else context.newParserInstance(targetSource)
+		// Viewer links can contain an extra episode slug. Preserve the series path,
+		// including Canvas, while discarding episode-specific path/query components.
+		val seriesUrl = link.newBuilder()
+			.encodedPath("/" + link.encodedPathSegments.take(3).joinToString("/") + "/list")
+			.query(null)
+			.addQueryParameter("title_no", titleNo.toString())
+			.fragment(null)
+			.build()
+		return parser.getDetails(
+			Manga(
+				id = parser.generateUid(titleNo),
+				title = "",
+				altTitles = emptySet(),
+				url = titleNo.toString(),
+				publicUrl = seriesUrl.toString(),
+				rating = RATING_UNKNOWN,
+				contentRating = null,
+				coverUrl = "",
+				tags = emptySet(),
+				state = null,
+				authors = emptySet(),
+				source = targetSource,
+			),
+		)
+	}
 
 	override val availableSortOrders: EnumSet<SortOrder> = EnumSet.of(
 		SortOrder.POPULARITY,

--- a/src/test/kotlin/org/koitharu/kotatsu/parsers/site/all/WebtoonsParserTest.kt
+++ b/src/test/kotlin/org/koitharu/kotatsu/parsers/site/all/WebtoonsParserTest.kt
@@ -1,0 +1,196 @@
+package org.koitharu.kotatsu.parsers.site.all
+
+import kotlinx.coroutines.test.runTest
+import okhttp3.CookieJar
+import okhttp3.HttpUrl
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.koitharu.kotatsu.parsers.MangaLoaderContext
+import org.koitharu.kotatsu.parsers.SourceConfigMock
+import org.koitharu.kotatsu.parsers.bitmap.Bitmap
+import org.koitharu.kotatsu.parsers.model.Manga
+import org.koitharu.kotatsu.parsers.model.MangaParserSource
+import org.koitharu.kotatsu.parsers.model.MangaSource
+import org.koitharu.kotatsu.parsers.util.generateUid
+
+internal class WebtoonsParserTest {
+
+    private val locales = mapOf(
+        "en" to MangaParserSource.WEBTOONS_EN,
+        "id" to MangaParserSource.WEBTOONS_ID,
+        "es" to MangaParserSource.WEBTOONS_ES,
+        "fr" to MangaParserSource.WEBTOONS_FR,
+        "th" to MangaParserSource.WEBTOONS_TH,
+        "zh-hant" to MangaParserSource.WEBTOONS_ZH,
+        "de" to MangaParserSource.WEBTOONS_DE,
+    )
+
+    @Test
+    fun genericResolverRoutesEveryLocale() = runTest {
+        for ((locale, target) in locales) {
+            val context = FixtureContext()
+            val url = "https://www.webtoons.com/$locale/fantasy/example/list?title_no=123"
+
+            val manga = context.newLinkResolver(url).getManga()
+
+            assertResolved(context, manga, target, url, "webtoon")
+        }
+    }
+
+    @Test
+    fun activeAndLegacyEntryParsersRouteToUrlLocale() = runTest {
+        val cases = listOf(
+            MangaParserSource.WEBTOONS_EN to MangaParserSource.WEBTOONS_FR,
+            MangaParserSource.LINEWEBTOONS_DE to MangaParserSource.WEBTOONS_ID,
+        )
+        for ((initial, target) in cases) {
+            val locale = locales.entries.single { it.value == target }.key
+            val context = FixtureContext()
+            val resolver = context.newLinkResolver(
+                "https://www.webtoons.com/$locale/canvas/example/list?title_no=123",
+            )
+
+            val manga = context.newParserInstance(initial).resolveLink(resolver, resolver.link)
+
+            assertResolved(context, manga, target, resolver.link.toString(), "canvas")
+        }
+    }
+
+    @Test
+    fun supportedHostsAndLinkShapesNormalizeToSeries() = runTest {
+        val cases = listOf(
+            LinkCase(
+                input = "https://webtoons.com/en/fantasy/example/list?title_no=123&sortOrder=ASC#series",
+                expected = "https://webtoons.com/en/fantasy/example/list?title_no=123",
+                type = "webtoon",
+            ),
+            LinkCase(
+                input = "https://www.webtoons.com/en/canvas/example/viewer?episode_no=45&title_no=123#comments",
+                expected = "https://www.webtoons.com/en/canvas/example/list?title_no=123",
+                type = "canvas",
+            ),
+            LinkCase(
+                input = "https://m.webtoons.com/en/fantasy/example/episode-one/viewer?title_no=123&episode_no=45",
+                expected = "https://m.webtoons.com/en/fantasy/example/list?title_no=123",
+                type = "webtoon",
+            ),
+        )
+        for (case in cases) {
+            val context = FixtureContext()
+            val resolver = context.newLinkResolver(case.input)
+
+            val manga = context.newParserInstance(MangaParserSource.WEBTOONS_EN)
+                .resolveLink(resolver, resolver.link)
+
+            assertResolved(context, manga, MangaParserSource.WEBTOONS_EN, case.expected, case.type)
+        }
+    }
+
+    @Test
+    fun malformedLinksReturnNullWithoutRequestsAtParserBoundary() = runTest {
+        val invalid = listOf(
+            "https://webtoons.com.example.org/en/fantasy/example/list?title_no=123",
+            "https://www.webtoons.com/unsupported/fantasy/example/list?title_no=123",
+            "https://www.webtoons.com/en/fantasy/example/search?title_no=123",
+            "https://www.webtoons.com/en/fantasy/example/extra/list?title_no=123",
+            "https://www.webtoons.com/en/fantasy/example/list",
+            "https://www.webtoons.com/en/fantasy/example/list?title_no=123&title_no=456",
+            "https://www.webtoons.com/en/fantasy/example/list?title_no=garbage",
+            "https://www.webtoons.com/en/fantasy/example/list?title_no=0",
+            "https://www.webtoons.com/en/fantasy/example/list?title_no=9223372036854775808",
+        )
+        val context = FixtureContext()
+        val parser = context.newParserInstance(MangaParserSource.WEBTOONS_EN)
+
+        for (url in invalid) {
+            val resolver = context.newLinkResolver(url)
+            assertNull(parser.resolveLink(resolver, resolver.link), url)
+        }
+        assertTrue(context.requests.isEmpty())
+    }
+
+    private fun assertResolved(
+        context: FixtureContext,
+        manga: Manga?,
+        target: MangaParserSource,
+        publicUrl: String,
+        type: String,
+    ) {
+        requireNotNull(manga)
+        assertEquals(target, manga.source)
+        assertEquals(context.newParserInstance(target).generateUid(123L), manga.id)
+        assertEquals("123", manga.url)
+        assertEquals("Fixture title", manga.title)
+        assertEquals(publicUrl, manga.publicUrl)
+        assertEquals(publicUrl, context.requests.first().toString())
+        assertEquals(2, context.requests.size)
+        assertEquals("/api/v1/$type/123/episodes", context.requests.last().encodedPath)
+        assertEquals(target, manga.chapters!!.single().source)
+        assertEquals(target, manga.tags.single().source)
+    }
+
+    private data class LinkCase(
+        val input: String,
+        val expected: String,
+        val type: String,
+    )
+
+    /** Synthetic HTTP responses only: no connections to live manga sites. */
+    private class FixtureContext : MangaLoaderContext() {
+        val requests = mutableListOf<HttpUrl>()
+
+        override val cookieJar = CookieJar.NO_COOKIES
+
+        override val httpClient = OkHttpClient.Builder().addInterceptor { chain ->
+            val request = chain.request()
+            requests.add(request.url)
+            val isApi = request.url.encodedPath.startsWith("/api/")
+            val body = if (isApi) {
+                """
+                    {
+                      "result": {
+                        "episodeList": [{
+                          "episodeTitle": "Episode 1",
+                          "episodeNo": 1,
+                          "viewerLink": "https://webtoons.com/en/a/b/viewer?title_no=123&episode_no=1",
+                          "exposureDateMillis": 0
+                        }]
+                      }
+                    }
+                """.trimIndent()
+            } else {
+                """<html><head><meta property="og:title" content="Fixture title"></head>
+                    <body><h2 class="genre">Fantasy</h2></body></html>"""
+            }
+            Response.Builder()
+                .request(request)
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .body(body.toResponseBody((if (isApi) "application/json" else "text/html").toMediaType()))
+                .build()
+        }.build()
+
+        override fun getConfig(source: MangaSource) = SourceConfigMock()
+
+        override fun getDefaultUserAgent() = "WebtoonsParserTest"
+
+        @Deprecated("Provide a base url")
+        override suspend fun evaluateJs(script: String): String? = error("Unexpected JavaScript")
+
+        override suspend fun evaluateJs(baseUrl: String, script: String, timeout: Long): String? =
+            error("Unexpected JavaScript")
+
+        override fun redrawImageResponse(response: Response, redraw: (Bitmap) -> Bitmap): Response =
+            error("Unexpected image")
+
+        override fun createBitmap(width: Int, height: Int): Bitmap = error("Unexpected image")
+    }
+}


### PR DESCRIPTION
## Summary

Added direct-link resolution for Webtoons series and viewer URLs.

Previously, Webtoons links could be picked up by the wrong locale parser, or by one of the broken legacy LineWebtoons sources, because every locale shares the same domain. The locale in the URL is now used to route the link to the correct source. This supports all seven existing Webtoons locales, Originals and Canvas links, and the bare, `www`, and mobile hosts.

This is admittedly something of a hackjob compatibility solution. The proper fix would probably be to merge the separate Webtoons sources into one parser and distinguish locales using the existing language tag system. Doing that now would change source identity and generated IDs, potentially breaking existing library entries, bookmarks, and history. This instead preserves the existing sources and routes links between them.

Viewer URLs are normalized back to their containing series. Pasting an episode URL will therefore open the correct manga, but the specific `episode_no` is still ignored. Directly opening the linked episode is not implemented yet and remains broken.

## Testing

I tested the parser fork against downstream Futon and confirmed that links for all seven locales can be pasted into the app and open the correct manga/webtoon.

I also added a focused regression test covering locale routing, active and legacy entry sources, series and viewer URL variants, Originals and Canvas links, supported hosts, source-specific IDs, and malformed links.